### PR TITLE
Removed user creation phase since new package is now creating user

### DIFF
--- a/tasks/prepare_server.yaml
+++ b/tasks/prepare_server.yaml
@@ -23,12 +23,6 @@
     insertafter="^[Service]"
     line=LimitNOFILE=8192
 
-- name: Configure group ldap
-  group: name=ldap gid=389
-
-- name: Configure user ldap
-  user: name=ldap comment="Dirsrv user" uid=389 group=ldap shell=/sbin/nologin
-
 - name: Check that firewalld service is active
   command: systemctl is-active firewalld
   register: firewalld_results

--- a/templates/ldap.inf.j2
+++ b/templates/ldap.inf.j2
@@ -1,7 +1,7 @@
 [General]
 FullMachineName= {{ ansible_nodename }}
-SuiteSpotUserID= ldap
-SuiteSpotGroup= ldap
+SuiteSpotUserID= dirsrv
+SuiteSpotGroup= dirsrv
 AdminDomain= {{ admin_domain }}
 ConfigDirectoryAdminID= admin
 ConfigDirectoryAdminPwd= {{ admin_password }}


### PR DESCRIPTION
Starting from package version "1.3.5.10-12.el7_3" it is automatically creating user called "dirsrv" with UID "389", so there is no need to create user any more.